### PR TITLE
#78 Added functionality for accessing the current ModelInstanceRepository implementation outside of the GenerationContext

### DIFF
--- a/fermenter-mda/src/main/java/org/technologybrewery/fermenter/mda/metamodel/ModelInstanceRepositoryManager.java
+++ b/fermenter-mda/src/main/java/org/technologybrewery/fermenter/mda/metamodel/ModelInstanceRepositoryManager.java
@@ -10,19 +10,43 @@ public final class ModelInstanceRepositoryManager {
 
     private static ThreadLocal<Map<String, Object>> threadBoundInstance = ThreadLocal.withInitial(HashMap::new);
 
+    private static final String ABSTRACT_MODEL_INSTANCE_REPOSITORY_CLASS_NAME = 
+                                "org.technologybrewery.fermenter.mda.metamodel.AbstractModelInstanceRepository";
+
     private ModelInstanceRepositoryManager() {
         // prevent private instantiation of all static class
     }
 
     /**
-     * Adds a repository. Only one repository of each type will be kept.
+     * Sets a repository as the repository implementation for its own class and any super 
+     * classes if present. This enables downstream projects to safely extend upstream 
+     * {@link ModelInstanceRepository}'s without breaking existing calls to getRepository().
      * 
-     * @param respository
+     * For example, given the classes:
+     *  MIR_A implements AbstractModelInstanceRepository
+     *  MIR_B extends MIR_A
+     *  MIR_C extends MIR_B
+     * 
+     * When the repository is set using setRepository(MIR_C). Then following calls to 
+     * getRepository would all return the MIR_C instance:
+     *  getMetamodelRepository(MIR_A.class) -> MIR_C
+     *  getMetamodelRepository(MIR_B.class) -> MIR_C
+     *  getMetamodelRepository(MIR_C.class) -> MIR_C
+     * 
+     * @param repository
      *            repository to add
      */
-    public static void setRepository(ModelInstanceRepository respository) {
+    public static void setRepository(ModelInstanceRepository repository) {
         Map<String, Object> instanceMap = threadBoundInstance.get();
-        instanceMap.put(respository.getClass().toString(), respository);
+
+        instanceMap.put(repository.getClass().toString(), repository);
+        Class<?> repositorySuperClass = repository.getClass().getSuperclass();
+
+        // Add an entry for all superclasses of the repository
+        while (!repositorySuperClass.getName().equals(ABSTRACT_MODEL_INSTANCE_REPOSITORY_CLASS_NAME)) {
+            instanceMap.put(repositorySuperClass.toString(), repository);
+            repositorySuperClass = repositorySuperClass.getSuperclass();
+        }
     }
 
     /**

--- a/fermenter-mda/src/test/java/org/technologybrewery/fermenter/mda/metamodel/MetadataRepositoryManagerTest.java
+++ b/fermenter-mda/src/test/java/org/technologybrewery/fermenter/mda/metamodel/MetadataRepositoryManagerTest.java
@@ -62,6 +62,27 @@ public class MetadataRepositoryManagerTest {
     }
 
     @Test
+    public void testMetadataRepositoryExtension() {
+        // Set the repository to the lowest subclass
+        TestMetadataRepository testRepositoryExtensionB = new TestMetadataRepositoryExtensionB(null);
+        ModelInstanceRepositoryManager.setRepository(testRepositoryExtensionB);
+
+        // Get the repository extension with its superclass references
+        TestMetadataRepository managedTestRespository = ModelInstanceRepositoryManager
+                .getMetamodelRepository(TestMetadataRepository.class);
+        assertEquals(testRepositoryExtensionB, managedTestRespository);
+
+        managedTestRespository = ModelInstanceRepositoryManager
+                .getMetamodelRepository(TestMetadataRepositoryExtensionA.class);
+        assertEquals(testRepositoryExtensionB, managedTestRespository);
+
+        // Get the repository extension with its current class reference
+        managedTestRespository = ModelInstanceRepositoryManager
+                .getMetamodelRepository(TestMetadataRepositoryExtensionB.class);
+        assertEquals(testRepositoryExtensionB, managedTestRespository);
+    }
+
+    @Test
     public void testClearMetadataReposistoryManager() {
         setNewDefaultMetadataRepository();
 
@@ -105,4 +126,22 @@ class TestMetadataRepository extends AbstractModelInstanceRepository {
 
     }
 
+}
+
+/**
+ * Used for testing only.
+ */
+class TestMetadataRepositoryExtensionA extends TestMetadataRepository {
+    public TestMetadataRepositoryExtensionA(ModelRepositoryConfiguration config) {
+        super(config);
+    }
+}
+
+/**
+ * Used for testing only.
+ */
+class TestMetadataRepositoryExtensionB extends TestMetadataRepositoryExtensionA {
+    public TestMetadataRepositoryExtensionB(ModelRepositoryConfiguration config) {
+        super(config);
+    }
 }


### PR DESCRIPTION
Some metamodel classes (ex: [RecordFieldTypeElement.java](https://github.com/boozallen/aissemble/blob/dev/foundation/foundation-mda/src/main/java/com/boozallen/aiops/mda/metamodel/element/RecordFieldTypeElement.java)) need access to the current `ModelInstanceRepository` before the `GenerationContext` has been created. 

Given `MIR_A implements ModelInstanceRepository` and `MIR_B extends MIR_A`, the old way fails when the implementation class for an execution is `MIR_B` but the upstream fermenter project still contains references to `MIR_A`. The new way allows for those references to remain intact while allowing others to extend their project.

Old way would return a NPE as `MIR_A.class` doesn't exist in the map, only `MIR_B.class`:
```
MIR_A modelRepository = ModelInstanceRepositoryManager.getMetamodelRepository(MIR_A.class);
```